### PR TITLE
add links to agda code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ Leandro T. C. Melo, Rodrigo Geraldo Ribeiro, Marcus Rodrigues de Araújo, Fernan
 
 Intrinsically-Typed Definitional Interpreters for Imperative Languages  
 Casper Bach Poulsen, Arjen Rouvoet, Andrew Tolmach, Robbert Krebbers, Eelco Visser  
-([preprint](http://casperbp.net/store/intrinsicallytyped.pdf))
+([preprint](http://casperbp.net/store/intrinsicallytyped.pdf),
+ [agda code](https://github.com/metaborg/mj.agda),
+ [rendered agda code](https://metaborg.github.io/mj.agda/)
+)
 
 JaVerT: JavaScript Verification Toolchain  
 José Fragoso Santos, Philippa Gardner, Petar Maksimović, Daiva Naudziuniene, Thomas Wood  

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ Leandro T. C. Melo, Rodrigo Geraldo Ribeiro, Marcus Rodrigues de Araújo, Fernan
 Intrinsically-Typed Definitional Interpreters for Imperative Languages  
 Casper Bach Poulsen, Arjen Rouvoet, Andrew Tolmach, Robbert Krebbers, Eelco Visser  
 ([preprint](http://casperbp.net/store/intrinsicallytyped.pdf),
- [agda code](https://github.com/metaborg/mj.agda),
- [rendered agda code](https://metaborg.github.io/mj.agda/)
+ [agda code](https://metaborg.github.io/mj.agda/)
 )
 
 JaVerT: JavaScript Verification Toolchain  


### PR DESCRIPTION
for "Intrinsically-Typed Definitional Interpreters for Imperative Languages"